### PR TITLE
Generate config metadata via spring-boot-configuration-processor

### DIFF
--- a/narayana-spring-boot-core/pom.xml
+++ b/narayana-spring-boot-core/pom.xml
@@ -67,6 +67,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Pull in the spring-boot-configuration-processor, which will [generate configuration metadata](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html) for @ConfigurationProperties sources, which will provide hints to IDEs (e.g. Eclipse) for autocompletion and validation