### PR TITLE
update to add xa recovery nodes configuration

### DIFF
--- a/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaProperties.java
+++ b/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaProperties.java
@@ -115,6 +115,11 @@ public class NarayanaProperties {
      */
     private Map<String, String> dbcp = new HashMap<>();
 
+    /**
+     * XA recovery nodes.
+     */
+    private List<String> xaRecoveryNodes = new ArrayList<>(Arrays.asList("1"));
+
     public String getLogDir() {
         return this.logDir;
     }
@@ -225,5 +230,13 @@ public class NarayanaProperties {
 
     public void setDbcp(Map<String, String> dbcp) {
         this.dbcp = dbcp;
+    }
+
+    public List<String> getXaRecoveryNodes() {
+        return this.xaRecoveryNodes;
+    }
+
+    public void setXaRecoveryNodes(List<String> xaRecoveryNodes) {
+        this.xaRecoveryNodes = xaRecoveryNodes;
     }
 }

--- a/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializer.java
+++ b/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializer.java
@@ -47,6 +47,7 @@ public class NarayanaPropertiesInitializer implements InitializingBean {
             return;
         }
         setNodeIdentifier(this.properties.getTransactionManagerId());
+        setXARecoveryNodes(this.properties.getXaRecoveryNodes());
         setObjectStoreDir(this.properties.getLogDir());
         setCommitOnePhase(this.properties.isOnePhaseCommit());
         setDefaultTimeout(this.properties.getDefaultTimeout());
@@ -69,6 +70,10 @@ public class NarayanaPropertiesInitializer implements InitializingBean {
         } catch (CoreEnvironmentBeanException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    private void setXARecoveryNodes(List<String> xaRecoveryNodes) {
+        getPopulator(JTAEnvironmentBean.class).setXaRecoveryNodes(xaRecoveryNodes);
     }
 
     private void setObjectStoreDir(String objectStoreDir) {


### PR DESCRIPTION
The period recovery process shows this INFO message repeatedly 
`2019-03-22 13:23:12.791  INFO 25429 --- [riodic Recovery] com.arjuna.ats.jta                     
 ARJUNA016017: No XA recovery nodes specified. May not recover orphans.
`
I just update to add the xarecovery nodes in the properties and the default value is {"1"}