### PR TITLE
Remove jbossts-properties.xml file from narayana-spring-boot-core

### DIFF
--- a/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializer.java
+++ b/narayana-spring-boot-core/src/main/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializer.java
@@ -25,8 +25,6 @@ import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
-import com.arjuna.common.util.propertyservice.PropertiesFactory;
-import org.jboss.logging.Logger;
 import org.springframework.beans.factory.InitializingBean;
 
 /**
@@ -36,8 +34,6 @@ import org.springframework.beans.factory.InitializingBean;
  */
 public class NarayanaPropertiesInitializer implements InitializingBean {
 
-    private static final Logger logger = Logger.getLogger(NarayanaPropertiesInitializer.class);
-
     private final NarayanaProperties properties;
 
     public NarayanaPropertiesInitializer(NarayanaProperties narayanaProperties) {
@@ -45,10 +41,6 @@ public class NarayanaPropertiesInitializer implements InitializingBean {
     }
 
     public void afterPropertiesSet() {
-        if (isPropertiesFileAvailable()) {
-            logger.info("Non-empty Narayana properties file found, ignoring Narayana application properties");
-            return;
-        }
         setNodeIdentifier(this.properties.getTransactionManagerId());
         setXARecoveryNodes(this.properties.getXaRecoveryNodes());
         setObjectStoreDir(this.properties.getLogDir());
@@ -59,13 +51,6 @@ public class NarayanaPropertiesInitializer implements InitializingBean {
         setXaResourceOrphanFilters(this.properties.getXaResourceOrphanFilters());
         setRecoveryModules(this.properties.getRecoveryModules());
         setExpiryScanners(this.properties.getExpiryScanners());
-    }
-
-    private boolean isPropertiesFileAvailable() {
-        // If the Narayana default properties are equal to the System properties,
-        // it means that either the Narayana properties file is missing or it is empty.
-        return !PropertiesFactory.getDefaultProperties().stringPropertyNames()
-                .equals(System.getProperties().stringPropertyNames());
     }
 
     private void setNodeIdentifier(String nodeIdentifier) {

--- a/narayana-spring-boot-core/src/main/resources/jbossts-properties.xml
+++ b/narayana-spring-boot-core/src/main/resources/jbossts-properties.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
-<properties/>

--- a/narayana-spring-boot-core/src/test/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializerTests.java
+++ b/narayana-spring-boot-core/src/test/java/me/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializerTests.java
@@ -48,7 +48,7 @@ class NarayanaPropertiesInitializerTests {
     }
 
     @Test
-    void shouldSetDefaultProperties() throws Exception {
+    void shouldSetDefaultProperties() {
         NarayanaProperties narayanaProperties = new NarayanaProperties();
         NarayanaPropertiesInitializer narayanaPropertiesInitializer =
                 new NarayanaPropertiesInitializer(narayanaProperties);
@@ -57,7 +57,7 @@ class NarayanaPropertiesInitializerTests {
         assertThat(BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class)
                 .getNodeIdentifier()).isEqualTo("1");
         assertThat(BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class)
-                .getObjectStoreDir()).endsWith("ObjectStore");
+                .getObjectStoreDir()).contains("ObjectStore");
         assertThat(BeanPopulator
                 .getNamedInstance(ObjectStoreEnvironmentBean.class, "communicationStore")
                 .getObjectStoreDir()).endsWith("ObjectStore");
@@ -99,7 +99,7 @@ class NarayanaPropertiesInitializerTests {
     }
 
     @Test
-    void shouldSetModifiedProperties() throws Exception {
+    void shouldSetModifiedProperties() {
         NarayanaProperties narayanaProperties = new NarayanaProperties();
         narayanaProperties.setTransactionManagerId("test-id");
         narayanaProperties.setLogDir("test-dir");


### PR DESCRIPTION
I don't know what was the original purpose of having an empty properties file within the API, but this is never a good idea as it could cause conflicts. Also, I didn't find anything in the documentation to sustain keeping this file. 

Fix https://github.com/snowdrop/narayana-spring-boot/issues/46