### PR TITLE
Upgrade to Camel 4.0.0-RC1, add bugfix to CamelServiceShutdownControllerAutoConfiguration and add integration test for un/successful round trip in recovery controller

### DIFF
--- a/openshift/recovery-controller/pom.xml
+++ b/openshift/recovery-controller/pom.xml
@@ -53,6 +53,51 @@
       <artifactId>camel-spring-boot</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-spring-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>me.snowdrop</groupId>
+      <artifactId>narayana-spring-boot-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
+<build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/NarayanaRecoveryTerminationControllerAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -48,8 +49,8 @@ public class NarayanaRecoveryTerminationControllerAutoConfiguration {
     @Bean
     @ConditionalOnProperty(value = "snowdrop.narayana.openshift.recovery.log-scraping-error-detection-enabled", matchIfMissing = true)
     @ConditionalOnMissingBean(LogScrapingRecoveryErrorDetector.class)
-    public LogScrapingRecoveryErrorDetector logScrapingRecoveryErrorDetector(StatefulsetRecoveryControllerProperties properties) {
-        return new LogScrapingRecoveryErrorDetector(properties.getCurrentPodName(), properties.getLogScrapingErrorDetectionPattern());
+    public LogScrapingRecoveryErrorDetector logScrapingRecoveryErrorDetector(StatefulsetRecoveryControllerProperties properties, KubernetesClient kubernetesClient) {
+        return new LogScrapingRecoveryErrorDetector(properties.getCurrentPodName(), properties.getLogScrapingErrorDetectionPattern(), kubernetesClient);
     }
 
 }

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryControllerAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package me.snowdrop.boot.narayana.openshift.recovery;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -40,10 +42,16 @@ public class StatefulsetRecoveryControllerAutoConfiguration {
         return new PodStatusManager(properties);
     }
 
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean(KubernetesClient.class)
+    public KubernetesClient kubernetesClient() {
+        return new DefaultOpenShiftClient();
+    }
+
     @Bean
     @ConditionalOnMissingBean(StatefulsetRecoveryController.class)
-    public StatefulsetRecoveryController statefulsetRecoveryController(StatefulsetRecoveryControllerProperties properties, PodStatusManager podStatusManager) {
-        return new StatefulsetRecoveryController(properties, podStatusManager);
+    public StatefulsetRecoveryController statefulsetRecoveryController(StatefulsetRecoveryControllerProperties properties, PodStatusManager podStatusManager, KubernetesClient kubernetesClient) {
+        return new StatefulsetRecoveryController(properties, podStatusManager, kubernetesClient);
     }
 
 }

--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/camel/CamelServiceShutdownControllerAutoConfiguration.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/camel/CamelServiceShutdownControllerAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +37,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @AutoConfigureAfter({CamelAutoConfiguration.class})
 @AutoConfigureBefore({NarayanaRecoveryTerminationControllerAutoConfiguration.class})
-@ConditionalOnBean({CamelContext.class})
 public class CamelServiceShutdownControllerAutoConfiguration {
 
     @Bean

--- a/openshift/recovery-controller/src/test/java/me/snowdrop/boot/narayana/openshift/recovery/RecoveryControllerIT.java
+++ b/openshift/recovery-controller/src/test/java/me/snowdrop/boot/narayana/openshift/recovery/RecoveryControllerIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.snowdrop.boot.narayana.openshift.recovery;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.time.Duration;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import me.snowdrop.boot.narayana.openshift.recovery.camel.CamelServiceShutdownControllerAutoConfiguration.CamelServiceShutdownController;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootApplication
+class RecoveryControllerIT {
+
+    private static KubernetesMockServer kubernetesServer;
+    private static KubernetesClient kubernetesClient;
+
+    private static final Pod READY;
+    private static final PodList READY_LIST;
+
+    static {
+        READY = new PodBuilder()
+                .withNewMetadata()
+                .withResourceVersion("1")
+                .withName("pod-0")
+                .withNamespace("test")
+                .endMetadata()
+                .withNewStatus()
+                .addNewCondition()
+                .withType("Ready")
+                .withStatus("True")
+                .endCondition()
+                .endStatus()
+                .build();
+        READY_LIST = new PodListBuilder()
+                .withNewMetadata()
+                .withResourceVersion("1")
+                .endMetadata()
+                .withItems(READY)
+                .build();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        kubernetesServer = new KubernetesMockServer(false);
+        kubernetesServer.init();
+        kubernetesClient = kubernetesServer.createClient();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        kubernetesClient.close();
+        kubernetesServer.destroy();
+    }
+
+    @AfterEach
+    void afterEach() {
+        kubernetesServer.reset();
+        kubernetesClient = kubernetesServer.createClient();
+    }
+
+    @Test
+    void successfulRoundtripTest() throws Exception {
+        kubernetesServer.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod-0")
+                .andReturn(HttpURLConnection.HTTP_OK, READY_LIST)
+                .always();
+        kubernetesServer.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test/pods/pod-0")
+                .andReturn(HttpURLConnection.HTTP_OK, READY)
+                .always();
+        kubernetesServer.expect().withPath("/api/v1/namespaces/test/pods/pod-0/log?pretty=false&follow=true")
+                .andReturnChunked(HttpURLConnection.HTTP_OK,
+                        "LOG-SCRAPING-START",
+                        System.lineSeparator(),
+                        "LOG-SCRAPING-STOP",
+                        System.lineSeparator())
+                .once();
+
+        ConfigurableApplicationContext applicationContext = SpringApplication.run(RecoveryControllerIT.class, new String[0]);
+        assertThat(new File("target/status/pod-0")).content().isEqualTo("RUNNING");
+        ServiceShutdownController ssc = applicationContext.getBean(ServiceShutdownController.class);
+        assertThat(ssc).isInstanceOf(CamelServiceShutdownController.class);
+        RecoveryErrorDetector red = applicationContext.getBean(RecoveryErrorDetector.class);
+        assertThat(red).isInstanceOf(LogScrapingRecoveryErrorDetector.class);
+        assertThat(applicationContext.getBean(PodStatusManager.class)).isNotNull();
+        assertThat(applicationContext.getBean(NarayanaRecoveryTerminationController.class)).isNotNull();
+        assertThat(applicationContext.getBean(StatefulsetRecoveryController.class)).isNotNull();
+        await("Let StatefulsetRecoveryController work a bit").pollDelay(Duration.ofSeconds(5)).until(() -> true);
+        applicationContext.close();
+        assertThat(new File("target/status/pod-0")).content().isEqualTo("STOPPED");
+    }
+
+    @Test
+    void unsuccessfulRoundtripTest() throws Exception {
+        kubernetesServer.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test/pods?fieldSelector=metadata.name%3Dpod-0")
+                .andReturn(HttpURLConnection.HTTP_OK, READY_LIST)
+                .always();
+        kubernetesServer.expect()
+                .get()
+                .withPath("/api/v1/namespaces/test/pods/pod-0")
+                .andReturn(HttpURLConnection.HTTP_OK, READY)
+                .always();
+        kubernetesServer.expect().withPath("/api/v1/namespaces/test/pods/pod-0/log?pretty=false&follow=true")
+                .andReturnChunked(HttpURLConnection.HTTP_OK,
+                        "LOG-SCRAPING-START",
+                        System.lineSeparator(),
+                        "WARN",
+                        System.lineSeparator(),
+                        "LOG-SCRAPING-STOP",
+                        System.lineSeparator())
+                .once();
+
+        ConfigurableApplicationContext applicationContext = SpringApplication.run(RecoveryControllerIT.class, new String[0]);
+        assertThat(new File("target/status/pod-0")).content().isEqualTo("RUNNING");
+        await("Let StatefulsetRecoveryController work a bit").pollDelay(Duration.ofSeconds(5)).until(() -> true);
+        applicationContext.close();
+        assertThat(new File("target/status/pod-0")).content().isEqualTo("PENDING");
+    }
+
+    @TestConfiguration
+    public static class SpringConfig {
+
+        @Bean
+        public KubernetesClient kubernetesClient() {
+            return RecoveryControllerIT.kubernetesClient;
+        }
+    }
+}

--- a/openshift/recovery-controller/src/test/resources/application.yaml
+++ b/openshift/recovery-controller/src/test/resources/application.yaml
@@ -1,0 +1,9 @@
+logging.level.me.snowdrop.boot.narayana.openshift.recovery: DEBUG
+
+narayana.log-dir: ./target/tx-object-store
+
+snowdrop.narayana.openshift.recovery.enabled: true
+snowdrop.narayana.openshift.recovery.status-dir: ./target/status
+snowdrop.narayana.openshift.recovery.statefulset: pod
+snowdrop.narayana.openshift.recovery.current-pod-name: pod-0
+snowdrop.narayana.openshift.recovery.period: 1000

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <agroal.version>2.2</agroal.version>
     <awaitility.version>4.2.0</awaitility.version>
     <byteman.version>4.0.21</byteman.version>
-    <camel-spring-boot.version>4.0.0-M3</camel-spring-boot.version>
+    <camel-spring-boot.version>4.0.0-RC1</camel-spring-boot.version>
     <narayana.version>6.0.1.Final</narayana.version>
     <openshift-client.version>6.7.2</openshift-client.version>
     <spring-boot.version>3.1.1</spring-boot.version>
@@ -104,8 +104,18 @@
         <version>${openshift-client.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-server-mock</artifactId>
+        <version>${openshift-client.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-spring-boot</artifactId>
+        <version>${camel-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-test-spring-junit5</artifactId>
         <version>${camel-spring-boot.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- Update Camel 4 from M3 to RC1
- Fix bug in CamelServiceShutdownControllerAutoConfiguration
- Extract DefaultOpenShiftClient creation to AutoConfiguration to make testable
- Add successful and unsuccessful roundtrip integration tests to verify bean creation and interaction with Kubernetes API

Hi @Sgitario, could plz review this fix.
Thx Benjamin