### PR TITLE
Shorten node identifier if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Narayana project [documentation](http://narayana.io/docs/project/index.html).
 
 > To ensure that multiple transaction managers can safely coordinate the same resource managers, each Narayana instance
 must be configured with a unique ID. By default, this ID is set to 1. To ensure uniqueness in production, you should
-configure the `narayana.transaction-manager-id` property with a different value for each instance of your application.
+configure the `narayana.node-identifier` property with a different value for each instance of your application. This value
+must not exceed a length of 28 bytes. To ensure that the value is shorten to a valid length by hashing with SHA-224,
+configure `narayana.shorten-node-identifier-if-necessary` property to true.
 
 # Using databases
 

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/properties/NarayanaProperties.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/properties/NarayanaProperties.java
@@ -41,9 +41,14 @@ public class NarayanaProperties {
     private String logDir;
 
     /**
-     * Unique transaction manager id.
+     * Unique node identifier.
      */
-    private String transactionManagerId = "1";
+    private String nodeIdentifier = "1";
+
+    /**
+     * Shorten node identifier if exceed a length of 28 bytes.
+     */
+    private boolean shortenNodeIdentifierIfNecessary = false;
 
     /**
      * Enable one phase commit optimization.
@@ -138,12 +143,30 @@ public class NarayanaProperties {
         this.logDir = logDir;
     }
 
+    @Deprecated(forRemoval = true)
     public String getTransactionManagerId() {
-        return this.transactionManagerId;
+        return getNodeIdentifier();
     }
 
-    public void setTransactionManagerId(String transactionManagerId) {
-        this.transactionManagerId = transactionManagerId;
+    @Deprecated(forRemoval = true)
+    public void setTransactionManagerId(String nodeIdentifier) {
+        setNodeIdentifier(nodeIdentifier);
+    }
+
+    public String getNodeIdentifier() {
+        return this.nodeIdentifier;
+    }
+
+    public void setNodeIdentifier(String nodeIdentifier) {
+        this.nodeIdentifier = nodeIdentifier;
+    }
+
+    public boolean isShortenNodeIdentifierIfNecessary() {
+        return this.shortenNodeIdentifierIfNecessary;
+    }
+
+    public void setShortenNodeIdentifierIfNecessary(boolean shortenNodeIdentifierIfNecessary) {
+        this.shortenNodeIdentifierIfNecessary = shortenNodeIdentifierIfNecessary;
     }
 
     public boolean isOnePhaseCommit() {

--- a/narayana-spring-boot-core/src/test/java/dev/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializerTests.java
+++ b/narayana-spring-boot-core/src/test/java/dev/snowdrop/boot/narayana/core/properties/NarayanaPropertiesInitializerTests.java
@@ -116,7 +116,7 @@ class NarayanaPropertiesInitializerTests {
     @Test
     void shouldSetModifiedProperties() {
         NarayanaProperties narayanaProperties = new NarayanaProperties();
-        narayanaProperties.setTransactionManagerId("test-id-1");
+        narayanaProperties.setNodeIdentifier("test-id-1");
         narayanaProperties.setXaRecoveryNodes(List.of("test-id-1", "test-id-2"));
         narayanaProperties.setLogDir("test-dir");
         narayanaProperties.setDefaultTimeout(1);
@@ -160,5 +160,19 @@ class NarayanaPropertiesInitializerTests {
         assertThat(BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class)
                 .getExpiryScannerClassNames())
                 .isEqualTo(List.of("test-scanner-1", "test-scanner-2"));
+    }
+
+    @Test
+    void shouldSetShortenNodeIdentifier() {
+        NarayanaProperties narayanaProperties = new NarayanaProperties();
+        narayanaProperties.setNodeIdentifier("x".repeat(30));
+
+        narayanaProperties.setShortenNodeIdentifierIfNecessary(true);
+        NarayanaPropertiesInitializer narayanaPropertiesInitializer =
+                new NarayanaPropertiesInitializer(narayanaProperties);
+        narayanaPropertiesInitializer.afterPropertiesSet();
+
+        assertThat(BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class)
+                .getNodeIdentifierBytes().length).isEqualTo(28);
     }
 }


### PR DESCRIPTION
Reintroduce feature originally introduced by #136 based on a new enhancement to Narayana 7.0.2 (jbosstm/narayana#2259). Analogous to Quarkus an explicit flag `narayana.shorten-node-identifier-if-necessary` has been added to activate the shortening feature (false by default!)

In this context, the property coming from the old Spring-Boot days `narayana.transaction-manager-id` has been deprecated in favour of `narayana.node-identifier` to better reflect the real meaning of the property (adjust to Narayana internal naming!).