### PR TITLE
Make pooled-jms dependency optional

### DIFF
--- a/narayana-spring-boot-core/pom.xml
+++ b/narayana-spring-boot-core/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
         <groupId>org.messaginghub</groupId>
         <artifactId>pooled-jms</artifactId>
+        <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/narayana-spring-boot-starter-it/pom.xml
+++ b/narayana-spring-boot-starter-it/pom.xml
@@ -55,6 +55,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.messaginghub</groupId>
+      <artifactId>pooled-jms</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jakarta-server</artifactId>
       <scope>test</scope>

--- a/narayana-spring-boot-starter/pom.xml
+++ b/narayana-spring-boot-starter/pom.xml
@@ -48,6 +48,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.messaginghub</groupId>
+      <artifactId>pooled-jms</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>

--- a/narayana-spring-boot-starter/src/main/java/dev/snowdrop/boot/narayana/autoconfigure/NarayanaAutoConfiguration.java
+++ b/narayana-spring-boot-starter/src/main/java/dev/snowdrop/boot/narayana/autoconfigure/NarayanaAutoConfiguration.java
@@ -33,7 +33,9 @@ import dev.snowdrop.boot.narayana.core.jms.GenericXAConnectionFactoryWrapper;
 import dev.snowdrop.boot.narayana.core.jms.PooledXAConnectionFactoryWrapper;
 import dev.snowdrop.boot.narayana.core.properties.NarayanaProperties;
 import dev.snowdrop.boot.narayana.core.properties.NarayanaPropertiesInitializer;
+import org.apache.commons.pool2.PooledObject;
 import org.jboss.tm.XAResourceRecoveryRegistry;
+import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -185,7 +187,7 @@ public class NarayanaAutoConfiguration {
     }
 
     @ConditionalOnProperty(name = "narayana.messaginghub.enabled", havingValue = "true")
-    @ConditionalOnClass(Message.class)
+    @ConditionalOnClass({Message.class, JmsPoolConnectionFactory.class, PooledObject.class })
     static class PooledJmsConfiguration {
 
         @Bean


### PR DESCRIPTION
@geoand: Should have been optional from the very beginning, Might force people to explicitly import dependency. Documentation in #178.