### PR TITLE
Last resource support for JMS

### DIFF
--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/PooledXAConnectionFactoryWrapper.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/PooledXAConnectionFactoryWrapper.java
@@ -63,6 +63,7 @@ public class PooledXAConnectionFactoryWrapper extends AbstractXAConnectionFactor
     protected ConnectionFactory wrapConnectionFactoryInternal(XAConnectionFactory xaConnectionFactory) {
         JmsPoolNarayanaConnectionFactory pooledConnectionFactory = new JmsPoolNarayanaConnectionFactory();
         pooledConnectionFactory.setName(this.properties.getName());
+        pooledConnectionFactory.setLastResource(this.properties.isLastResource());
         pooledConnectionFactory.setTransactionManager(this.transactionManager);
         pooledConnectionFactory.setConnectionFactory(xaConnectionFactory);
         pooledConnectionFactory.setMaxConnections(this.properties.getMaxConnections());

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/JmsPoolNarayanaConnectionFactory.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/JmsPoolNarayanaConnectionFactory.java
@@ -30,6 +30,7 @@ public class JmsPoolNarayanaConnectionFactory extends JmsPoolXAConnectionFactory
     private static final long serialVersionUID = 1709204966732828338L;
 
     private String name;
+    private boolean lastResource;
 
     public String getName() {
         return this.name;
@@ -39,13 +40,21 @@ public class JmsPoolNarayanaConnectionFactory extends JmsPoolXAConnectionFactory
         this.name = name;
     }
 
+    public boolean isLastResource() {
+        return this.lastResource;
+    }
+
+    public void setLastResource(boolean lastResource) {
+        this.lastResource = lastResource;
+    }
+
     @Override
     protected PooledNarayanaConnection createPooledConnection(Connection connection) {
-        return new PooledNarayanaConnection(connection, getTransactionManager(), getName());
+        return new PooledNarayanaConnection(connection, getTransactionManager(), getName(), isLastResource());
     }
 
     @Override
     protected JmsPoolXAJMSContext newPooledConnectionContext(JmsPoolConnection connection, int sessionMode) {
-        return new JmsPoolNarayanaJmsContext(connection, sessionMode, getName());
+        return new JmsPoolNarayanaJmsContext(connection, sessionMode, getName(), isLastResource());
     }
 }

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/JmsPoolNarayanaJmsContext.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/JmsPoolNarayanaJmsContext.java
@@ -24,17 +24,25 @@ import org.messaginghub.pooled.jms.JmsPoolXAJMSContext;
 public class JmsPoolNarayanaJmsContext extends JmsPoolXAJMSContext {
 
     private final String name;
+    private final boolean lastResource;
 
-    public JmsPoolNarayanaJmsContext(JmsPoolConnection connection, int sessionMode, String name) {
+    public JmsPoolNarayanaJmsContext(JmsPoolConnection connection, int sessionMode, String name, boolean lastResource) {
         super(connection, sessionMode);
         this.name = name;
+        this.lastResource = lastResource;
     }
 
     @Override
     public XAResource getXAResource() {
         XAResource xares = super.getXAResource();
         if (this.name != null) {
-            xares = new NamedXAResource(xares, this.name);
+            if (this.lastResource) {
+                xares = new NamedLastXAResource(xares, this.name);
+            } else {
+                xares = new NamedXAResource(xares, this.name);
+            }
+        } else if (this.lastResource) {
+            xares = new LastXAResource(xares);
         }
         return xares;
     }

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/LastXAResource.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/LastXAResource.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.snowdrop.boot.narayana.core.jms.pool;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.jboss.tm.LastResource;
+
+public class LastXAResource implements XAResource, LastResource {
+    private final XAResource xaResource;
+
+    public LastXAResource(XAResource xaResource) {
+        this.xaResource = xaResource;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        this.xaResource.commit(xid, onePhase);
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+        this.xaResource.end(xid, flags);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        this.xaResource.forget(xid);
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return this.xaResource.getTransactionTimeout();
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xaRes) throws XAException {
+        return this.xaResource.isSameRM(xaRes);
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        return this.xaResource.prepare(xid);
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+        return this.xaResource.recover(flag);
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        this.xaResource.rollback(xid);
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int seconds) throws XAException {
+        return this.xaResource.setTransactionTimeout(seconds);
+    }
+
+    @Override
+    public void start(Xid xid, int flags) throws XAException {
+        this.xaResource.start(xid, flags);
+    }
+
+
+}

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/NamedLastXAResource.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/NamedLastXAResource.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.snowdrop.boot.narayana.core.jms.pool;
+
+import javax.transaction.xa.XAResource;
+
+import org.jboss.tm.LastResource;
+
+public class NamedLastXAResource extends NamedXAResource implements LastResource {
+    public NamedLastXAResource(XAResource xaResource, String name) {
+        super(xaResource, name);
+    }
+}

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/PooledNarayanaConnection.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/jms/pool/PooledNarayanaConnection.java
@@ -28,19 +28,26 @@ import org.messaginghub.pooled.jms.pool.PooledXAConnection;
 public class PooledNarayanaConnection extends PooledXAConnection {
 
     private final String name;
+    private final boolean lastResource;
 
-    public PooledNarayanaConnection(Connection connection, TransactionManager transactionManager, String name) {
+    public PooledNarayanaConnection(Connection connection, TransactionManager transactionManager, String name, boolean lastResource) {
         super(connection, transactionManager);
         this.name = name;
+        this.lastResource = lastResource;
     }
 
     @Override
     protected XAResource createXaResource(JmsPoolSession session) throws JMSException {
         XAResource xares = super.createXaResource(session);
         if (this.name != null) {
-            xares = new NamedXAResource(xares, this.name);
+            if (this.lastResource) {
+                xares = new NamedLastXAResource(xares, this.name);
+            } else {
+                xares = new NamedXAResource(xares, this.name);
+            }
+        } else if (this.lastResource) {
+            xares = new LastXAResource(xares);
         }
         return xares;
     }
-
 }

--- a/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/properties/MessagingHubConnectionFactoryProperties.java
+++ b/narayana-spring-boot-core/src/main/java/dev/snowdrop/boot/narayana/core/properties/MessagingHubConnectionFactoryProperties.java
@@ -22,6 +22,7 @@ public class MessagingHubConnectionFactoryProperties {
 
     private boolean enabled = false;
     private String name = "jms";
+    private boolean lastResource = false;
     private int maxConnections = 1;
     private Duration connectionIdleTimeout = Duration.ofSeconds(30);
     private Duration connectionCheckInterval = Duration.ofMillis(-1);
@@ -45,6 +46,14 @@ public class MessagingHubConnectionFactoryProperties {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public boolean isLastResource() {
+        return this.lastResource;
+    }
+
+    public void setLastResource(boolean lastResource) {
+        this.lastResource = lastResource;
     }
 
     public int getMaxConnections() {


### PR DESCRIPTION
  This pull request adds LastResource support to the XAConnectionFactoryWrapper for messaginghub pooled jms. When lastResource is set to true, the XAResource that will be enlisted in the Transaction will be an object that implements the LastResource tagging interface. When the LastResource tagging interface is found by Narayana, the XAResource will be the last one in the commit order, meaning the commit to this resource will be later than any other enlisted resources.

  Since the addition of NamedXAResource in [this commit](https://github.com/snowdrop/narayana-spring-boot/commit/450fbfa3a5d358bc896449f1479b45848c9c79dd), the returned XAResource is wrapped in an XAResourceWrapper. This hides the actual instance class and/or any additional interfaces that the XAResource was implementing. In our case, we were providing an XAResource that was also a LastResource, which is now hidden due to the NamedXAResource and so narayana will no longer treat the resource as a last resource. This pull request adds a LastXAResource and a NamedLastXAResource to support LastResource as well as NamedXAResource.
  
  The use case is that an application might receive a JMS message, perform some work on one or more databases and then send an event that some work has been 'done'. Due to the fact that the ConnectionFactory that is used for sending is also the one used to receive the initiating JMS message, it is by default the first resource in the commit order. So when the XA Transaction is being committed, the JMS message will be sent before work on the database(s) is committed. A situation may now occur that a JMS message describes an event that some work has been performed on a database, while this work is not yet committed. Another application may receive this event and query the database before the transaction branch for the work is actually committed and so cannot find the work that has been done according to the received event. This may lead to an exception and retry in the best case and wrong behavior in the worst case.
