### PR TITLE
Upgrade camel to 4.14.0 and spring-boot to 3.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
     <agroal.version>2.8</agroal.version>
     <awaitility.version>4.2.2</awaitility.version>
     <byteman.version>4.0.25</byteman.version>
-    <camel.version>4.10.6</camel.version>
-    <camel-spring-boot.version>4.10.6</camel-spring-boot.version>
+    <camel.version>4.14.0</camel.version>
+    <camel-spring-boot.version>4.14.0</camel-spring-boot.version>
     <narayana.version>7.2.2.Final</narayana.version>
     <openshift-client.version>7.3.1</openshift-client.version>
-    <spring-boot.version>3.4.7</spring-boot.version>
+    <spring-boot.version>3.5.4</spring-boot.version>
 
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>


### PR DESCRIPTION
@graben Camel 4.14.0 was just released and is a LTS release.     camel-spring-boot 4.14.0 uses spring-boot 3.5.4.     Can we bump spring-boot to 3.5 for narayana-spring-boot 3.4.3 or does that need to wait for a 3.5.0?